### PR TITLE
Acts as taggable through

### DIFF
--- a/lib/acts_as_taggable_on/taggable.rb
+++ b/lib/acts_as_taggable_on/taggable.rb
@@ -37,7 +37,7 @@ module ActsAsTaggableOn
     #     acts_as_taggable_on :languages, :skills
     #   end
     def acts_as_taggable_on(*tag_types)
-      taggable_on(false, tag_types)
+      taggable_on(false, self, self.primary_key, tag_types)
     end
 
     ##
@@ -51,7 +51,25 @@ module ActsAsTaggableOn
     #     acts_as_ordered_taggable_on :languages, :skills
     #   end
     def acts_as_ordered_taggable_on(*tag_types)
-      taggable_on(true, tag_types)
+      taggable_on(true, self, self.primary_key, tag_types)
+    end
+
+    #
+    # Allows a model to access the tags of another model
+    #
+    # @param [Class] taggable_class A taggable class
+    # @param [Array] tag_types An array of taggable contexts
+    #
+    # Example:
+    #   class Doc < ActiveRecord::Base
+    #     acts_as_taggable_through User, :user_id
+    #   end
+    #
+    #   class User < ActiveRecord::Base
+    #     acts_as_taggable_on :languages, :skills
+    #   end
+    def acts_as_taggable_through(taggable_class, taggable_key)
+      taggable_on(true, taggable_class, taggable_key, taggable_class.tag_types)
     end
 
     private
@@ -67,7 +85,7 @@ module ActsAsTaggableOn
       # NB: method overridden in core module in order to create tag type
       #     associations and methods after this logic has executed
       #
-    def taggable_on(preserve_tag_order, *tag_types)
+    def taggable_on(preserve_tag_order, taggable_class, taggable_key, *tag_types)
       tag_types = tag_types.to_a.flatten.compact.map(&:to_sym)
 
       if taggable?
@@ -76,8 +94,15 @@ module ActsAsTaggableOn
       else
         class_attribute :tag_types
         self.tag_types = tag_types
+
         class_attribute :preserve_tag_order
         self.preserve_tag_order = preserve_tag_order
+
+        class_attribute :taggable_class
+        self.taggable_class = taggable_class
+
+        class_attribute :taggable_key
+        self.taggable_key = taggable_key
 
         class_eval do
           has_many :taggings, as: :taggable, dependent: :destroy, class_name: '::ActsAsTaggableOn::Tagging'

--- a/lib/acts_as_taggable_on/taggable.rb
+++ b/lib/acts_as_taggable_on/taggable.rb
@@ -69,7 +69,10 @@ module ActsAsTaggableOn
     #     acts_as_taggable_on :languages, :skills
     #   end
     def acts_as_taggable_through(taggable_class, taggable_key)
-      taggable_on(true, taggable_class, taggable_key, taggable_class.tag_types)
+      taggable_on(taggable_class.preserve_tag_order,
+                  taggable_class,
+                  taggable_key,
+                  taggable_class.tag_types)
     end
 
     private

--- a/lib/acts_as_taggable_on/taggable/core.rb
+++ b/lib/acts_as_taggable_on/taggable/core.rb
@@ -60,6 +60,10 @@ module ActsAsTaggableOn::Taggable
         object.column_names.map { |column| "#{object.table_name}.#{column}" }.join(', ')
       end
 
+      def taggable_class
+        self
+      end
+
       ##
       # Return a scope of objects that are tagged with the specified tags.
       #
@@ -96,9 +100,12 @@ module ActsAsTaggableOn::Taggable
 
         context = options.delete(:on)
         owned_by = options.delete(:owned_by)
-        alias_base_name = undecorated_table_name.gsub('.', '_')
+        alias_base_name = taggable_class.send(:undecorated_table_name).gsub('.', '_')
         # FIXME use ActiveRecord's connection quote_column_name
         quote = ActsAsTaggableOn::Utils.using_postgresql? ? '"' : ''
+
+        taggable_type = quote_value(taggable_class.bass_class.name, nil)
+        tagagble_id = "#{quote}#{table_name}#{quote}.#{primary_key}"
 
         if options.delete(:exclude)
           if options.delete(:wild)
@@ -107,12 +114,12 @@ module ActsAsTaggableOn::Taggable
             tags_conditions = tag_list.map { |t| sanitize_sql(["#{ActsAsTaggableOn::Tag.table_name}.name #{ActsAsTaggableOn::Utils.like_operator} ?", t]) }.join(' OR ')
           end
 
-          conditions << "#{table_name}.#{primary_key} NOT IN (SELECT #{ActsAsTaggableOn::Tagging.table_name}.taggable_id FROM #{ActsAsTaggableOn::Tagging.table_name} JOIN #{ActsAsTaggableOn::Tag.table_name} ON #{ActsAsTaggableOn::Tagging.table_name}.tag_id = #{ActsAsTaggableOn::Tag.table_name}.#{ActsAsTaggableOn::Tag.primary_key} AND (#{tags_conditions}) WHERE #{ActsAsTaggableOn::Tagging.table_name}.taggable_type = #{quote_value(base_class.name, nil)})"
+          conditions << "#{table_name}.#{primary_key} NOT IN (SELECT #{ActsAsTaggableOn::Tagging.table_name}.taggable_id FROM #{ActsAsTaggableOn::Tagging.table_name} JOIN #{ActsAsTaggableOn::Tag.table_name} ON #{ActsAsTaggableOn::Tagging.table_name}.tag_id = #{ActsAsTaggableOn::Tag.table_name}.#{ActsAsTaggableOn::Tag.primary_key} AND (#{tags_conditions}) WHERE #{ActsAsTaggableOn::Tagging.table_name}.taggable_type = #{taggable_type})"
 
           if owned_by
             joins <<  "JOIN #{ActsAsTaggableOn::Tagging.table_name}" +
-                      "  ON #{ActsAsTaggableOn::Tagging.table_name}.taggable_id = #{quote}#{table_name}#{quote}.#{primary_key}" +
-                      " AND #{ActsAsTaggableOn::Tagging.table_name}.taggable_type = #{quote_value(base_class.name, nil)}" +
+                      "  ON #{ActsAsTaggableOn::Tagging.table_name}.taggable_id = #{taggable_id}" +
+                      " AND #{ActsAsTaggableOn::Tagging.table_name}.taggable_type = #{taggable_type}" +
                       " AND #{ActsAsTaggableOn::Tagging.table_name}.tagger_id = #{quote_value(owned_by.id, nil)}" +
                       " AND #{ActsAsTaggableOn::Tagging.table_name}.tagger_type = #{quote_value(owned_by.class.base_class.to_s, nil)}"
 
@@ -139,8 +146,8 @@ module ActsAsTaggableOn::Taggable
           )
 
           tagging_cond = "#{ActsAsTaggableOn::Tagging.table_name} #{taggings_alias}" +
-                          " WHERE #{taggings_alias}.taggable_id = #{quote}#{table_name}#{quote}.#{primary_key}" +
-                          " AND #{taggings_alias}.taggable_type = #{quote_value(base_class.name, nil)}"
+                          " WHERE #{taggings_alias}.taggable_id = #{taggable_id}" +
+                          " AND #{taggings_alias}.taggable_type = #{taggable_type}"
 
           tagging_cond << " AND " + sanitize_sql(["#{taggings_alias}.created_at >= ?", options.delete(:start_at)]) if options[:start_at]
           tagging_cond << " AND " + sanitize_sql(["#{taggings_alias}.created_at <= ?", options.delete(:end_at)])   if options[:end_at]
@@ -173,8 +180,8 @@ module ActsAsTaggableOn::Taggable
           tags.each do |tag|
             taggings_alias = adjust_taggings_alias("#{alias_base_name[0..11]}_taggings_#{ActsAsTaggableOn::Utils.sha_prefix(tag.name)}")
             tagging_join = "JOIN #{ActsAsTaggableOn::Tagging.table_name} #{taggings_alias}" \
-                "  ON #{taggings_alias}.taggable_id = #{quote}#{table_name}#{quote}.#{primary_key}" +
-                " AND #{taggings_alias}.taggable_type = #{quote_value(base_class.name, nil)}" +
+                "  ON #{taggings_alias}.taggable_id = #{taggable_id}" +
+                " AND #{taggings_alias}.taggable_type = #{taggable_type}" +
                 " AND #{taggings_alias}.tag_id = #{quote_value(tag.id, nil)}"
 
             tagging_join << " AND " + sanitize_sql(["#{taggings_alias}.created_at >= ?", options.delete(:start_at)]) if options[:start_at]
@@ -205,8 +212,8 @@ module ActsAsTaggableOn::Taggable
         elsif options.delete(:match_all)
           taggings_alias, _ = adjust_taggings_alias("#{alias_base_name}_taggings_group"), "#{alias_base_name}_tags_group"
           joins << "LEFT OUTER JOIN #{ActsAsTaggableOn::Tagging.table_name} #{taggings_alias}" \
-              "  ON #{taggings_alias}.taggable_id = #{quote}#{table_name}#{quote}.#{primary_key}" \
-              " AND #{taggings_alias}.taggable_type = #{quote_value(base_class.name, nil)}"
+              "  ON #{taggings_alias}.taggable_id = #{taggable_id}" \
+              " AND #{taggings_alias}.taggable_type = #{taggable_type}"
 
           joins << " AND " + sanitize_sql(["#{taggings_alias}.context = ?", context.to_s]) if context
           joins << " AND " + sanitize_sql(["#{ActsAsTaggableOn::Tagging.table_name}.created_at >= ?", options.delete(:start_at)]) if options[:start_at]

--- a/spec/acts_as_taggable_on/taggable_spec.rb
+++ b/spec/acts_as_taggable_on/taggable_spec.rb
@@ -1,6 +1,22 @@
 # encoding: utf-8
 require 'spec_helper'
 
+describe 'Taggable Through Another Model' do
+  it 'should have tagged_with' do
+    taggable = TaggableModel.create!(name: 'Bob Jones')
+    taggable_through = TaggableThroughModel.create!(name: 'Brad Jones', foreign_id: taggable.id)
+
+    expect(TaggableModel.tagged_with([:awesome]).to_a).to eq([])
+    expect(TaggableThroughModel.tagged_with([:awesome]).to_a).to eq([])
+
+    taggable.tag_list = %w(awesome epic)
+    taggable.save
+
+    expect(TaggableModel.tagged_with([:awesome]).to_a).to eq([taggable])
+    expect(TaggableThroughModel.tagged_with([:awesome]).to_a).to eq([taggable_through])
+  end
+end
+
 describe 'Taggable To Preserve Order' do
   before(:each) do
     @taggable = OrderedTaggableModel.new(name: 'Bob Jones')

--- a/spec/internal/app/models/models.rb
+++ b/spec/internal/app/models/models.rb
@@ -33,6 +33,10 @@ class AlteredInheritingTaggableModel < TaggableModel
   acts_as_taggable_on :parts
 end
 
+class TaggableThroughModel < ActiveRecord::Base
+  acts_as_taggable_through TaggableModel, :foreign_id
+end
+
 class Market < ActsAsTaggableOn::Tag
 end
 

--- a/spec/internal/db/schema.rb
+++ b/spec/internal/db/schema.rb
@@ -60,6 +60,11 @@ ActiveRecord::Schema.define version: 0 do
     t.column :cached_glass_list, :string
   end
 
+  create_table :taggable_through_models, force: true do |t|
+    t.column :name, :string
+    t.column :foreign_id, :integer
+  end
+
   create_table :companies, force: true do |t|
     t.column :name, :string
   end


### PR DESCRIPTION
The best way I can explain this is with an example.

Lets have a `Doc` record which has `user_id` and `User` record which is taggable.

In `acts-as-taggable-on` at the moment to find all of the `Doc`s where their `User` has a given tag we would have to run a query like:

```
Doc.where(user: User.tagged_with('foo'))
```

Whereas it might be nicer to write:

```
Doc.tagged_with('foo')
```

and have the following setup:

```
class Doc < ActiveRecord::Base
  acts_as_taggable_through User, :user_id
end

class User < ActiveRecord::Base
  acts_as_taggable_on :languages, :skills
end
```

In particularly this is useful for models which whose table is a view where we might want to share the tags between the view and the table.
